### PR TITLE
Nest assets under branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ before_install:
 script:
   - rm -f pkg/*
   - "buildscripts/${BUILD_ENGINE}.sh"
-  - mkdir -p "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/"
+  - mkdir -p "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/"
   - sudo chown -R "$USER" pkg
-  - mv pkg "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/pkg"
-  - ls -lah "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/pkg"
+  - mv pkg "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
+  - ls -lah "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
 deploy:
   skip_cleanup: true
   provider: s3


### PR DESCRIPTION
This ensures we can safely build multiple branches without confusing the
(upcoming) auto-update mechanism and pointing our downloads at the wrong
CLI version.