### PR TITLE
Dynamic Uno - Support

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -26,6 +26,7 @@ override :zlib, source: {
 # aptible-cli dependencies/components
 override :ruby, version: '2.2.4'
 dependency 'aptible-cli'
+dependency 'ssh'
 
 # Version manifest file
 dependency 'version-manifest'

--- a/config/software/aptible-cli.rb
+++ b/config/software/aptible-cli.rb
@@ -1,5 +1,5 @@
 name 'aptible-cli'
-default_version 'v0.7.5'
+default_version 'v0.8.0'
 
 license 'MIT'
 license_file 'LICENSE.md'

--- a/config/software/ssh.rb
+++ b/config/software/ssh.rb
@@ -1,0 +1,30 @@
+name 'ssh'
+default_version '7.3p1'
+
+dependency 'zlib'
+dependency 'openssl'
+
+license 'BSD'
+license_file 'LICENCE'
+
+source url: 'http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/' \
+            "openssh-#{version}.tar.gz"
+
+version '7.3p1' do
+  source sha1: 'bfade84283fcba885e2084343ab19a08c7d123a5'
+end
+
+relative_path "openssh-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  command './configure' \
+    " --prefix=#{install_dir}/embedded", env: env
+
+  %w(ssh-keygen ssh).each do |binary|
+    make binary, env: env
+    command "install -m 0755 #{binary} #{install_dir}/embedded/bin/#{binary}",
+            env: env
+  end
+end


### PR DESCRIPTION
We'd like to start using UNIX port-forwards on the server side for DB
tunnels, but that feature shipped only two years ago (...), so users are
likely to have SSH versions that don't support it (e.g. Trusty and
Precise).

This solves that by including OpenSSH in our binary, and putting it on
the `PATH` when we run the Aptible CLI (I've also included a tweak I had
laying around to unset `APPBUNDLER_ALLOW_RVM` when running the Aptible
CLI).

---

Note: I've also updated Omnibus here (in order to update Omnibus Software, which I needed to grab an updated version of the `config_guess` recipe).

cc @fancyremarker @blakepettersson 