### PR TITLE
Windows: use a .exe entrypoint rather than .bat

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -25,6 +25,7 @@ override :zlib, source: {
 
 # aptible-cli dependencies/components
 dependency 'aptible-cli'
+dependency 'aptible-cli-entrypoint'
 dependency 'ssh'
 
 override :ruby,     version: '2.3.1'

--- a/config/software/aptible-cli-entrypoint.rb
+++ b/config/software/aptible-cli-entrypoint.rb
@@ -1,0 +1,75 @@
+name 'aptible-cli-entrypoint'
+
+build do
+  def windows_escaped_path(*components)
+    windows_safe_path(*components).gsub(File::ALT_SEPARATOR) do
+      "#{File::ALT_SEPARATOR}#{File::ALT_SEPARATOR}"
+    end
+  end
+
+  env = {
+    'APPBUNDLER_ALLOW_RVM' => '',
+    'BUNDLE_ORIG_PATH' => '',
+    'BUNDLE_ORIG_GEM_PATH' => '',
+    'BUNDLE_BIN_PATH' => '',
+    'BUNDLE_GEMFILE' => '',
+    'RUBY_ROOT' => '',
+    'RUBYOPT' => '',
+    'RUBY_ENGINE' => '',
+    'RUBY_VERSION' => '',
+    'RUBYLIB' => '',
+
+    'APTIBLE_TOOLBELT' => '1'
+  }
+
+  if windows?
+    bindir = windows_escaped_path(install_dir, 'embedded', 'bin')
+
+    cert_components = [install_dir, 'embedded', 'ssl', 'certs']
+    env['SSL_CERT_DIR'] = windows_escaped_path(*cert_components)
+    env['SSL_CERT_FILE'] = windows_escaped_path(*cert_components, 'cacert.pem')
+
+    build = "#{install_dir}/embedded/src"
+    mkdir build
+
+    erb(
+      source: 'aptible.c.erb',
+      dest: windows_safe_path(build, 'aptible.c'),
+      vars: { env: env, bindir: bindir }
+    )
+
+    vcvarsall = windows_safe_path(
+      'C:', 'Program Files (x86)', 'Microsoft Visual Studio', '2017',
+      'Community', 'VC', 'Auxiliary', 'Build', 'vcvarsall.bat'
+    )
+
+    command %("#{vcvarsall}" x86_amd64 8.1 && cl /W2 /WX aptible.c),
+            cwd: build
+
+    exe = 'aptible.exe'
+    move("#{build}/#{exe}", "#{install_dir}/bin/#{exe}")
+  else
+    cli_entrypoint = "#{install_dir}/bin/aptible"
+
+    block do
+      require 'shellwords'
+
+      File.open(cli_entrypoint, 'w') do |f|
+        f.puts('#!/bin/sh')
+
+        env.each do |k, v|
+          if v == ''
+            f.puts(%(unset #{k}))
+          else
+            f.puts(%(export #{k}=#{Shellwords.escape(v)}))
+          end
+        end
+        f.puts(%(export PATH="#{install_dir}/embedded/bin:$PATH"))
+
+        f.puts(%(exec "#{install_dir}/embedded/bin/aptible" "$@"))
+      end
+
+      command "chmod 755 #{cli_entrypoint}"
+    end
+  end
+end

--- a/config/software/aptible-cli.rb
+++ b/config/software/aptible-cli.rb
@@ -24,38 +24,4 @@ build do
 
   # Now, create an aptible-cli binstub
   command "appbundler . '#{install_dir}/embedded/bin' aptible-cli", env: env
-
-  # And finally, create the entrypoint file. This unsets APPBUNDLER_ALLOW_RVM
-  # to ensure that can't accidentally break the CLI, and puts all our binaries
-  # on the PATH (this includes e.g. ssh).
-  cli_entrypoint = "#{install_dir}/bin/aptible"
-  cli_entrypoint = "#{cli_entrypoint}.bat" if windows?
-
-  vars_to_clear = %w(
-    APPBUNDLER_ALLOW_RVM BUNDLE_ORIG_PATH BUNDLE_ORIG_GEM_PATH BUNDLE_BIN_PATH
-    BUNDLE_GEMFILE RUBY_ROOT RUBYOPT RUBY_ENGINE RUBY_VERSION RUBYLIB
-  )
-
-  block do
-    File.open(cli_entrypoint, 'w') do |f|
-      if windows?
-        f.puts('@ECHO OFF')
-        vars_to_clear.each { |var| f.puts("SET #{var}=") }
-        f.puts('SET APTIBLE_TOOLBELT=1')
-        f.puts("SET PATH=#{install_dir}/embedded/bin;%PATH%")
-        certs = "#{install_dir}/embedded/ssl/certs"
-        f.puts("SET SSL_CERT_DIR=#{certs}")
-        f.puts("SET SSL_CERT_FILE=#{certs}/cacert.pem")
-        f.puts(%(@"#{install_dir}/embedded/bin/aptible.bat" %*))
-      else
-        f.puts('#!/bin/sh')
-        vars_to_clear.each { |var| f.puts("unset #{var}") }
-        f.puts(%(export APTIBLE_TOOLBELT="1"))
-        f.puts(%(export PATH="#{install_dir}/embedded/bin:$PATH"))
-        f.puts(%(exec "#{install_dir}/embedded/bin/aptible" "$@"))
-      end
-    end
-  end
-
-  command "chmod 755 #{cli_entrypoint}" unless windows?
 end

--- a/config/templates/aptible-cli-entrypoint/aptible.c.erb
+++ b/config/templates/aptible-cli-entrypoint/aptible.c.erb
@@ -1,0 +1,153 @@
+#define UNICODE
+#define _UNICODE
+
+#include <stdio.h>
+#include <string.h>
+#include <windows.h>
+#include <Strsafe.h>
+#include <ctype.h>
+
+#define BINDIR L"<%= bindir %>"
+#define RUBY L"<%= bindir %>\\ruby.exe"
+#define APTIBLE L"<%= bindir %>\\aptible"
+
+#define CMD_BUFFER_SIZE 8192
+#define PATH_BUFFER_SIZE 32768
+
+void printLastError(char *label) {
+  DWORD dLastError = GetLastError();
+  LPCTSTR strErrorMessage = NULL;
+
+  FormatMessage(
+      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_ARGUMENT_ARRAY | FORMAT_MESSAGE_ALLOCATE_BUFFER,
+      NULL,
+      dLastError,
+      0,
+      (LPWSTR) &strErrorMessage,
+      0,
+      NULL
+      );
+
+  printf("%s: %ls\n", label, strErrorMessage);
+}
+
+int main(void)  {
+  wchar_t *cl = GetCommandLine();
+
+  // Drop the first parameter (program name) from cl. We'll replace
+  // this with two things:
+  //
+  // - Ruby, which will be our new argv[0].
+  // - The path of the aptible ruby script.
+  //
+  // See Wine's implementation of CommandLineToArgvW for where this
+  // parsing comes from.
+
+  if (*cl == '"') {
+    ++cl;
+    while (*cl)
+      if (*cl++ == '"')
+        break;
+  } else {
+    while (*cl && *cl != ' ' && *cl != '\t')
+      ++cl;
+  }
+
+  /* (optionally) skip spaces preceding the first argument */
+  while (*cl == ' ' || *cl == '\t') {
+    cl++;
+  }
+
+  // Now, prepare the new command line
+  wchar_t commandLine[CMD_BUFFER_SIZE];
+
+  if (StringCchCopy(commandLine, CMD_BUFFER_SIZE, RUBY)) {
+    return 1;
+  }
+
+  if (StringCchCat(commandLine, CMD_BUFFER_SIZE, L" ")) {
+    return 1;
+  }
+
+  if (StringCchCat(commandLine, CMD_BUFFER_SIZE, APTIBLE)) {
+    return 1;
+  }
+
+  if (StringCchCat(commandLine, CMD_BUFFER_SIZE, L" ")) {
+    return 1;
+  }
+
+  if (StringCchCat(commandLine, CMD_BUFFER_SIZE, cl)) {
+    return 1;
+  }
+
+  // Prepare the environment
+  // (erb) <% env.each do |k, v| %>
+  if (_wputenv_s(L"<%= k %>", L"<%= v %>")) {
+    return 1;
+  }
+  // (erb) <% end %>
+
+  wchar_t newPath[PATH_BUFFER_SIZE];
+
+  if (StringCchCopy(newPath, PATH_BUFFER_SIZE, BINDIR)) {
+    return 1;
+  }
+
+  if (StringCchCat(newPath, PATH_BUFFER_SIZE, L";")) {
+    return 1;
+  }
+
+  wchar_t *currentPath = _wgetenv(L"PATH");
+  if (currentPath != NULL) {
+    if (StringCchCat(newPath, PATH_BUFFER_SIZE, currentPath)) {
+      return 1;
+    }
+  }
+
+  if (_wputenv_s(L"PATH", newPath)) {
+    return 1;
+  }
+
+  // Finally, spawn the Ruby process
+  STARTUPINFO info={sizeof(info)};
+  PROCESS_INFORMATION processInfo;
+
+  BOOL ok = CreateProcess(
+      RUBY,
+      commandLine,
+      NULL, NULL,
+      TRUE, 0,
+      NULL, NULL,
+      &info, &processInfo
+      );
+
+  if (!ok) {
+    // Oops, Ruby failed to start.
+    printLastError("CreateProcess");
+    return 1;
+  }
+
+  // Good: Ruby started. Wait for it and return an exit code.
+  int exitCode = 1;
+  DWORD rubyExitCode;
+
+  if (WaitForSingleObject(processInfo.hProcess, INFINITE)) {
+    printLastError("WaitForSingleObject");
+    goto done;
+  }
+
+  if (!GetExitCodeProcess(processInfo.hProcess, &rubyExitCode)) {
+    printLastError("GetExitCodeProcess");
+    goto done;
+  }
+
+  if (rubyExitCode == 0) {
+    exitCode = 0;
+  }
+
+done:
+  CloseHandle(processInfo.hProcess);
+  CloseHandle(processInfo.hThread);
+  return exitCode;
+}

--- a/doc/WINDOWS.md
+++ b/doc/WINDOWS.md
@@ -35,6 +35,9 @@ MSI tools and the SDK:
 https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
 ```
 
+Visual Studio Community Edition 2017, install the "Desktop Development with
+C++" and Windows 8.1 SDK components.
+
 Preparation
 -----------
 


### PR DESCRIPTION
We currently use a aptible.bat script as a shim on Windows in order to
set the environment variables we need, which is similar to what we do on
OSX / Linux where we use a /bin/sh script.

Unfortunately, while this works fine on OSX / Linux (where we have
access to `exec`), it's not so great on Windows:

- Calling a batch file from another batch file is a bad idea.
- It's unclear if you can even call a batch file from another program.
- I'm not sure what we're doing with the exit code, if anything.

And most importantly, whenever you CTRL+C out of the program, it
triggers an ugly and OCD-inducing "Terminate batch job (Y/N)" prompt,
and god knows what this prompt even does.

Anyhow, batch files are bad. So, let's replace them with something
better: a .exe shim, which doesn't have any of these issues!

This is what this PR does.

---

cc @fancyremarker 