### PR TITLE
Remove Travis Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: true
 language: ruby
 install: true
-cache:
-  - bundler
-  - directories:
-    - .local/cache
 matrix:
   include:
     - os: osx


### PR DESCRIPTION
It looks like all our master (i.e. release) builds on OSX are timing out
for some reason, but all PRs are passing. The main difference between
the two is caching (which, TBH, isn't super useful, since it's not
available for PRs), so I'm removing caching to see if that fixes the
issue.

Note that dropping the cache in Travis doesn't appear to actually do the
trick here (it looks like only the Bundler cache is being dropped).

---

FYI @fancyremarker 