### PR TITLE
Downgrade OSX to 10.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install: true
 matrix:
   include:
     - os: osx
+      osx_image: xcode8
       rvm: 2.2.4
       env:
         - BUILD_ENGINE=native


### PR DESCRIPTION
Our builds have been failing since Travis updated the default image to
10.12. I suspect the root cause has to do with signing timing out
(because it hangs at the very end of the build), but it's unclear why
the OSX upgrade might have caused this.

In the meantime, let's try to downgrade back to OSX 10.11 to fix the
issue.

---

Note: I'm PR'ing this from the Aptible repo so I can try and repro the problem (when PR'ing from a fork, we don't have credentials, so we don't sign)

FYI @fancyremarker 