### PR TITLE
2 build fixes

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -19,8 +19,14 @@ build_iteration 1
 # Creates required build directories
 dependency 'preparation'
 
+# https://github.com/chef/omnibus-software/issues/695
 override :zlib, source: {
   url: 'http://pilotfiber.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz'
+}
+
+# Don't use FTP. Travis blocks that traffic.
+override :libffi, source: {
+  url: 'http://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz'
 }
 
 # aptible-cli dependencies/components

--- a/config/software/aptible-cli.rb
+++ b/config/software/aptible-cli.rb
@@ -22,6 +22,6 @@ build do
   gem 'install ./aptible-cli-*.gem --local --no-ri --no-rdoc', env: env
 
   # Now, create an aptible-cli binstub
-  gem 'install appbundler --version 0.10.0 --no-ri --no-rdoc'
+  gem 'install appbundler --version 0.10.0 --no-ri --no-rdoc', env: env
   command "appbundler . '#{install_dir}/embedded/bin' aptible-cli", env: env
 end


### PR DESCRIPTION
- Fix the windows build
- Download libffi over HTTP as opposed to FTP (note: the checksum is checked after download) 

cc @fancyremarker 