### PR TITLE
[ci skip] Update Windows Signing Identity

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -68,7 +68,7 @@ package :msi do
   # (and we can't use `1` because Omnibus wants `true` or `false`). So,
   # aliasing `true` as `t` it is.
   t = true
-  signing_identity '9A25D0866E9F043B218CDB9225081DF2139AF2D2', machine_store: t
+  signing_identity '66594CDB20C947A81824533ED54060F8FFC30322', machine_store: t
 
   # Use WixUtilExtension to support WixBroadcastEnvironmentChange and notify
   # the system that we're updating an environment variable (the PATH).


### PR DESCRIPTION
We rolled our Windows signing certificate (the old one expired), so this updates the ID to the thumbprint of the new certificate.