### PR TITLE
Bump CLI to version 0.16.2

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -36,6 +36,7 @@ dependency 'ssh'
 
 override :ruby,     version: '2.3.1'
 override :rubygems, version: '2.4.8'
+override :bundler, version: '1.17.3'
 
 # Version manifest file
 dependency 'version-manifest'

--- a/config/software/aptible-cli.rb
+++ b/config/software/aptible-cli.rb
@@ -1,5 +1,5 @@
 name 'aptible-cli'
-default_version 'v0.16.1'
+default_version 'v0.16.2'
 
 license 'MIT'
 license_file 'LICENSE.md'


### PR DESCRIPTION
Bumps the CLI gem version, and pins the bundler version to the latest 1.x, due to the latest 2.x version causing an `This Gemfile requires a different version of Bundler.` error.