### PR TITLE
Use new windows code signing certficate

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -68,7 +68,7 @@ package :msi do
   # (and we can't use `1` because Omnibus wants `true` or `false`). So,
   # aliasing `true` as `t` it is.
   t = true
-  signing_identity '66594CDB20C947A81824533ED54060F8FFC30322', machine_store: t
+  signing_identity '‎c1d2d31515fc767767c32c71b655dffd7bfa45db', machine_store: t
 
   # Use WixUtilExtension to support WixBroadcastEnvironmentChange and notify
   # the system that we're updating an environment variable (the PATH).

--- a/doc/WINDOWS.md
+++ b/doc/WINDOWS.md
@@ -59,6 +59,9 @@ Authenticode Signing Key`). To do so, open the p12 file, select import in the
 `Local Machine`, and provide the p12 password (found in 1Password as well). Use
 the certificate manager to confirm the certificate was properly imported.
 
+If you install a new certificate, you will need to update the thumbprint in
+config/projects/aptible-toolbelt.rb
+
 ### Every time ###
 
 Use an **administrator prompt**, and set up the environment:


### PR DESCRIPTION
Use the currently valid DigiCert code signing certificate for Windows builds. 

Expires 3/26/2021.