### PR TITLE
Fix copy/paste error

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -68,7 +68,7 @@ package :msi do
   # (and we can't use `1` because Omnibus wants `true` or `false`). So,
   # aliasing `true` as `t` it is.
   t = true
-  signing_identity '‎c1d2d31515fc767767c32c71b655dffd7bfa45db', machine_store: t
+  signing_identity '1C1D2D31515FC767767C32C71B655DFFD7BFA45DB', machine_store: t
 
   # Use WixUtilExtension to support WixBroadcastEnvironmentChange and notify
   # the system that we're updating an environment variable (the PATH).


### PR DESCRIPTION
Changing to uppercase, but I think the real key here was there was some kind of unicode char before which wasn't at all obvious:

```
-  signing_identity '<U+200E>c1d2d31515fc767767c32c71b655dffd7bfa45db', machine_store: t
+  signing_identity '1C1D2D31515FC767767C32C71B655DFFD7BFA45DB', machine_store: t
```