### PR TITLE
Bump to 0.18.2

### DIFF
--- a/config/software/aptible-cli.rb
+++ b/config/software/aptible-cli.rb
@@ -1,5 +1,5 @@
 name 'aptible-cli'
-default_version 'v0.18.1'
+default_version 'v0.18.2'
 
 license 'MIT'
 license_file 'LICENSE.md'


### PR DESCRIPTION
Small change, updates to use the disk decorator that shows the correct IOPS for GP2 and GP3 volumes alike.
https://github.com/aptible/aptible-cli/compare/v0.18.1...v0.18.2