### PR TITLE
Remove runtime dependency on u2f-host

### DIFF
--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -19,12 +19,6 @@ build_iteration 1
 # Creates required build directories
 dependency 'preparation'
 
-# The version of chef-sugar our version of omnibus uses
-# doesn't support debian_after_or_at_stretch? or centos_7?
-if debian_after_jessie? || ubuntu_after_or_at_xenial?
-  runtime_dependency 'fido2-tools'
-end
-
 # https://github.com/chef/omnibus-software/issues/695
 override :zlib, source: {
   url: 'http://pilotfiber.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz'

--- a/config/projects/aptible-toolbelt.rb
+++ b/config/projects/aptible-toolbelt.rb
@@ -22,7 +22,7 @@ dependency 'preparation'
 # The version of chef-sugar our version of omnibus uses
 # doesn't support debian_after_or_at_stretch? or centos_7?
 if debian_after_jessie? || ubuntu_after_or_at_xenial?
-  runtime_dependency 'u2f-host'
+  runtime_dependency 'fido2-tools'
 end
 
 # https://github.com/chef/omnibus-software/issues/695


### PR DESCRIPTION
While `fido2-tools` is [required for webauthn support](https://github.com/Yubico/libfido2/issues/511) `chef-sugar` (the library we use to apply logic based on the current operating system and version does not support specifying the ubunbut/debian versions we need to apply this runtime dependency.

So for example, if a user installs `aptible-cli` on ubuntu 16.04 they will receive an error that a runtime dependency has not been met.  They would then need to add the yubico ppa first before installing `fido2-tools`.

Since we cannot accurately supply the requirements necessary for our dependencies, I think just removing the dependency and documenting how to install the dependencies makes the most sense to me.

