### PR TITLE
Added latest/all for omnibus release paths on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,21 @@ matrix:
       env:
         - BUILD_ENGINE=docker
         - DOCKER_TAG=ubuntu-1604
+        - PKG_FILE_EXT=.deb
       services:
         - docker
     - os: linux
       env:
         - BUILD_ENGINE=docker
         - DOCKER_TAG=debian-9
+        - PKG_FILE_EXT=.deb
       services:
         - docker
     - os: linux
       env:
         - BUILD_ENGINE=docker
         - DOCKER_TAG=centos-7
+        - PKG_FILE_EXT=.rpm
       services:
         - docker
 before_install:
@@ -26,10 +29,18 @@ before_install:
 script:
   - rm -f pkg/*
   - "buildscripts/${BUILD_ENGINE}.sh"
-  - mkdir -p "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/"
+  # create directories in preparation of moving to dest and chown
+  - mkdir -p "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/"
   - sudo chown -R "$USER" pkg
-  - mv pkg "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
-  - ls -lah "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
+  # copy build results to latest
+  - cp -R pkg "deploy/${TRAVIS_REPO_SLUG}/latest/"
+  - mv "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt*${PKG_FILE_EXT}" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}"
+  - mv "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt*${PKG_FILE_EXT}.metadata.json" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}.metadata.json"
+  # move pkg itself to 
+  - mv pkg "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
+  # list dirs to verify copy/mv commands succeeded 
+  - ls -lah "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
+  - ls -lah "deploy/${TRAVIS_REPO_SLUG}/latest"
 deploy:
   skip_cleanup: true
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ script:
   - rm -f pkg/*
   - "buildscripts/${BUILD_ENGINE}.sh"
   # create directories in preparation of moving to dest and chown
-  - mkdir -p "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/"
+  - mkdir -p "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/"
   - sudo chown -R "$USER" pkg
   # copy build results to latest
   - "buildscripts/set-latest.sh"
   # move pkg itself to destination slug path
-  - mv pkg "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
+  - mv pkg "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
   # list dirs to verify copy/mv commands succeeded 
-  - ls -lah "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
+  - ls -lah "deploy/${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
   - ls -lah "deploy/${TRAVIS_REPO_SLUG}/latest"
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,8 @@ script:
   - mkdir -p "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/"
   - sudo chown -R "$USER" pkg
   # copy build results to latest
-  - cp -R pkg "deploy/${TRAVIS_REPO_SLUG}/latest/"
-  - mv "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt*${PKG_FILE_EXT}" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}"
-  - mv "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt*${PKG_FILE_EXT}.metadata.json" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}.metadata.json"
-  # move pkg itself to 
+  - "buildscripts/set-latest.sh"
+  # move pkg itself to destination slug path
   - mv pkg "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"
   # list dirs to verify copy/mv commands succeeded 
   - ls -lah "deploy/${TRAVIS_REPO_SLUG}/all/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/pkg"

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbe
 
 
 # latest link
-https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_{{OS_TAG}}_{{CPU_ARCHITECTURE}}.{{DISTRO_PACKAGE_EXTENSION}}
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt_latest_{{OS_TAG}}_{{CPU_ARCHITECTURE}}.{{DISTRO_PACKAGE_EXTENSION}}
 
 # example deb link
-https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_debian.9.13-1_amd64.deb
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt_latest_debian.9.13-1_amd64.deb
 ```
 
 Developer Notes

--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ Downstream consumers of this repository's outputs include:
 
 MIT License, see [LICENSE](LICENSE.md) for details.
 
-Copyright (c) 2022 [Aptible](https://www.aptible.com) and contributors.
+Copyright (c) 2019 [Aptible](https://www.aptible.com) and contributors.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ Why use the Aptible Toolbelt?
   relies on (e.g. `pg_dump`). You might need to install those manually
   otherwise.
 
+Where can I download the Aptible Toolbelt?
+------------------------------------------
+
+The download links can be found [here in our documentation](https://deploy-docs.aptible.com/docs/cli). 
+
+These links are versioned semantically, but one can also download the __latest__ version with the following link: 
+
+```
+# versioned link
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/{{TRAVIS_BRANCH}}/all/{{CLI_BUILD_NUMBER}}/pkg/aptible-toolbelt_{{CLI_VERSION}}%2B{{CLI_TIMESTAMP}}~{{OS_TAG}}_{{CPU_ARCHITECTURE}}.{DISTRO_PACKAGE_EXTENSION}}
+
+
+# example versioned link
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/all/master/340/pkg/aptible-toolbelt_0.19.3%2B20220317192554~debian.9.13-1_amd64.deb
+
+
+# latest link
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_{{CPU_ARCHITECTURE}}.{{DISTRO_PACKAGE_EXTENSION}}
+
+# example deb link
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_amd64.deb
+```
+
 Developer Notes
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbe
 
 
 # latest link
-https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_{{CPU_ARCHITECTURE}}.{{DISTRO_PACKAGE_EXTENSION}}
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_{{OS_TAG}}_{{CPU_ARCHITECTURE}}.{{DISTRO_PACKAGE_EXTENSION}}
 
 # example deb link
-https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_amd64.deb
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_debian.9.13-1_amd64.deb
 ```
 
 Developer Notes

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ These links are versioned semantically, but one can also download the __latest__
 
 ```
 # versioned link
-https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/{{TRAVIS_BRANCH}}/all/{{CLI_BUILD_NUMBER}}/pkg/aptible-toolbelt_{{CLI_VERSION}}%2B{{CLI_TIMESTAMP}}~{{OS_TAG}}_{{CPU_ARCHITECTURE}}.{DISTRO_PACKAGE_EXTENSION}}
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/{{TRAVIS_BRANCH}}/{{CLI_BUILD_NUMBER}}/pkg/aptible-toolbelt_{{CLI_VERSION}}%2B{{CLI_TIMESTAMP}}~{{OS_TAG}}_{{CPU_ARCHITECTURE}}.{DISTRO_PACKAGE_EXTENSION}}
 
 
 # example versioned link
-https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/all/master/340/pkg/aptible-toolbelt_0.19.3%2B20220317192554~debian.9.13-1_amd64.deb
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/master/340/pkg/aptible-toolbelt_0.19.3%2B20220317192554~debian.9.13-1_amd64.deb
 
 
 # latest link
@@ -99,8 +99,18 @@ Use:
 DOCKER_TAG=debian-8 buildscripts/docker.sh
 ```
 
+### External Dependencies ### 
+
+Be cautious when making breaking changes to build result paths.
+
+Downstream consumers of this repository's outputs include:
+
+* [Our homebrew cask for OSX installation](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/aptible.rb)
+* [Our PR generate](https://github.com/aptible/toolbelt-auto-update/blob/master/bin/toolbelt-auto-update#L64-L65), which looks for new CLI versions and opens PR's against our public docs and aptible-integration repos
+* Update our [Windows and Mac OS package instructions](https://github.com/aptible/scripts/blob/master/doc/ReleaseNewCLIVersion.md)
+
 ## Copyright and License
 
 MIT License, see [LICENSE](LICENSE.md) for details.
 
-Copyright (c) 2019 [Aptible](https://www.aptible.com) and contributors.
+Copyright (c) 2022 [Aptible](https://www.aptible.com) and contributors.

--- a/buildscripts/set-latest.sh
+++ b/buildscripts/set-latest.sh
@@ -24,4 +24,4 @@ rename_file_copy_to_latest() {
 export -f rename_file_copy_to_latest
 
 cp -R pkg "deploy/${TRAVIS_REPO_SLUG}/latest/"
-find "deploy/${TRAVIS_REPO_SLUG}/latest" -name "aptible-toolbelt*" | xargs bash -c 'for arg; do rename_file_copy_to_latest "$arg"; done'
+find "deploy/${TRAVIS_REPO_SLUG}/latest" -name "aptible-toolbelt*" | xargs -I {} bash -c 'rename_file_copy_to_latest "$@"'

--- a/buildscripts/set-latest.sh
+++ b/buildscripts/set-latest.sh
@@ -24,4 +24,4 @@ rename_file_copy_to_latest() {
 export -f rename_file_copy_to_latest
 
 cp -R pkg "deploy/${TRAVIS_REPO_SLUG}/latest/"
-find "deploy/${TRAVIS_REPO_SLUG}/latest" -name "aptible-toolbelt*" | xargs -I {} bash -c 'rename_file_copy_to_latest "$@"'
+find "deploy/${TRAVIS_REPO_SLUG}/latest" -name "aptible-toolbelt*" | xargs -I {} bash -c 'rename_file_copy_to_latest "{}"'

--- a/buildscripts/set-latest.sh
+++ b/buildscripts/set-latest.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+# this file is needed because the version is set by: `"#{semver}~#{platform}.#{platform_version}"`
+# in `util/version.rb`, which contains a latest timestamp by default. this timestamp is generated in
+# the build and as such is not nown ahead of time. 
+
+# this script just searches for the latest build by file extension, and makes a copy of it as 'latest'
+# for use in s3. ideal replacement to this issue would be to use releases/builds in github itself
+
+rename_file_copy_to_latest() {
+    # drops all the stuff that's usually caught by the wildcard in the find function "*" and replaces with `latest``
+    if [[ "$1" == *".metadata.json" ]]; then
+        # moves metadata file with latest suffix
+        mv "$1" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${DOCKER_TAG}_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}.metadata.json"
+    elif [[ "$1" == *"${PKG_FILE_EXT}" ]]; then
+        # moves versioned file (rpm/deb) with latest suffix
+        mv "$1" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${DOCKER_TAG}_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}"
+    else
+        echo "Found file that will not be renamed: $1"
+    fi
+}
+export -f rename_file
+
+cp -R pkg "deploy/${TRAVIS_REPO_SLUG}/latest/"
+find "deploy/${TRAVIS_REPO_SLUG}/latest" -name "aptible-toolbelt*" | xargs bash -c 'for arg; do rename_file_copy_to_latest "$arg"; done'

--- a/buildscripts/set-latest.sh
+++ b/buildscripts/set-latest.sh
@@ -21,7 +21,7 @@ rename_file_copy_to_latest() {
         echo "Found file that will not be renamed: $1"
     fi
 }
-export -f rename_file
+export -f rename_file_copy_to_latest
 
 cp -R pkg "deploy/${TRAVIS_REPO_SLUG}/latest/"
 find "deploy/${TRAVIS_REPO_SLUG}/latest" -name "aptible-toolbelt*" | xargs bash -c 'for arg; do rename_file_copy_to_latest "$arg"; done'

--- a/buildscripts/set-latest.sh
+++ b/buildscripts/set-latest.sh
@@ -13,10 +13,10 @@ rename_file_copy_to_latest() {
     # drops all the stuff that's usually caught by the wildcard in the find function "*" and replaces with `latest``
     if [[ "$1" == *".metadata.json" ]]; then
         # moves metadata file with latest suffix
-        mv "$1" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${DOCKER_TAG}_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}.metadata.json"
+        mv "$1" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt_latest_${DOCKER_TAG}_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}.metadata.json"
     elif [[ "$1" == *"${PKG_FILE_EXT}" ]]; then
         # moves versioned file (rpm/deb) with latest suffix
-        mv "$1" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt-latest_${DOCKER_TAG}_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}"
+        mv "$1" "deploy/${TRAVIS_REPO_SLUG}/latest/aptible-toolbelt_latest_${DOCKER_TAG}_${TRAVIS_CPU_ARCH}${PKG_FILE_EXT}"
     else
         echo "Found file that will not be renamed: $1"
     fi


### PR DESCRIPTION
see title. we want to try to have a `latest` deb for ci usages with a direct latest url

---


Current link and expected side by side, but not sure (correct me if I'm mistaken please):

Edited (as in readme after changes):

```
VERSIONED

https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/all/master/340/pkg/aptible-toolbelt_0.19.3%2B20220317192554~debian.9.13-1_amd64.deb

LATEST 

https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt-latest_debian.9.13-1_amd64.deb
```


---

1. I checked [this past build](https://api.travis-ci.com/v3/job/564935038/log.txt) and it looks like it uses bash
2. I also tried to adhere to naming i caught in a slack thread

---

Provided some justification for approach in the shell script comment