### PR TITLE
fix: updated debian link on docs for latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbe
 https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt_latest_{{OS_TAG}}_{{CPU_ARCHITECTURE}}.{{DISTRO_PACKAGE_EXTENSION}}
 
 # example deb link
-https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt_latest_debian.9.13-1_amd64.deb
+https://omnibus-aptible-toolbelt.s3.amazonaws.com/aptible/omnibus-aptible-toolbelt/latest/aptible-toolbelt_latest_debian-9_amd64.deb
 ```
 
 Developer Notes


### PR DESCRIPTION
This link does work and is public:

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/2961973/187519434-4d2d9536-ec9b-46a0-a2e5-e8c0927beec3.png">

Caught this as we dropped some extra affixes to the version recently.