### PR TITLE
Bump version for release

### DIFF
--- a/config/software/aptible-cli.rb
+++ b/config/software/aptible-cli.rb
@@ -1,5 +1,5 @@
 name 'aptible-cli'
-default_version 'v0.19.3'
+default_version 'v0.19.4'
 
 license 'MIT'
 license_file 'LICENSE.md'


### PR DESCRIPTION
Requires https://github.com/aptible/aptible-cli/pull/311 to be merged and deployed to rubygems.